### PR TITLE
Add prompt for S3 bucket naming conventions to CloudFormation template

### DIFF
--- a/src/templates/aws-genomics-root-novpc.template.yaml
+++ b/src/templates/aws-genomics-root-novpc.template.yaml
@@ -55,8 +55,13 @@ Parameters:
     Type: List<AWS::EC2::Subnet::Id>
     Description: 'Subnets you want your batch compute environment to launch in. We recommend private subnets. NOTE: Must be from the VPC provided.'
   S3BucketName:
-    Description: A S3 bucket name for storing analysis results
+    Description: >-
+      A S3 bucket name for storing analysis results.
+      The bucket name must respect the S3 bucket naming conventions 
+      (can contain lowercase letters, numbers, periods and hyphens).
     Type: String
+    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+    ConstraintDescription: "Must respect AWS naming conventions"
   ExistingBucket:
     Description: Does this bucket already exist?
     Type: String

--- a/src/templates/aws-genomics-s3.template.yaml
+++ b/src/templates/aws-genomics-s3.template.yaml
@@ -16,6 +16,13 @@ Mappings:
 Parameters:
   S3BucketName:
     Type: String
+    Description: >-
+      A S3 bucket name for storing analysis results.
+      The bucket name must respect the S3 bucket naming conventions 
+      (can contain lowercase letters, numbers, periods and hyphens).
+    Type: String
+    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+    ConstraintDescription: "Must respect AWS naming conventions"
   ExistingBucket:
     Type: String
     Description: Does this bucket already exist? If not, it will be created.

--- a/src/templates/cromwell/cromwell-aio.template.yaml
+++ b/src/templates/cromwell/cromwell-aio.template.yaml
@@ -66,8 +66,13 @@ Parameters:
     Description: "Choose the two Availability Zones to deploy instances for AWS Batch."
     Type: List<AWS::EC2::AvailabilityZone::Name>
   S3BucketName:
-    Description: A S3 bucket name for storing analysis results
+    Description: >-
+      A S3 bucket name for storing analysis results. 
+      The bucket name must respect the S3 bucket naming conventions 
+      (can contain lowercase letters, numbers, periods and hyphens).
     Type: String
+    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+    ConstraintDescription: "Must respect S3 bucket naming conventions"
   ExistingBucket:
     Description: Does this bucket already exist?
     Type: String


### PR DESCRIPTION
I forgot about naming conventions when I created my bucket name, but it goes through the complete the cloud stack and fails with a naming convention error.

*Issue #, if available:*

*Description of changes:*

I've added a small prompt:

> The bucket name must respect the S3 bucket naming conventions (can contain lowercase letters, numbers, periods and hyphens).

I also added an `AllowedPattern` and `ConstraintDescription`, but I don't get validation on the form.
The `AllowedPattern` regex comes from the following StackOverflow answer: [Regex for s3 bucket name](https://stackoverflow.com/a/50484916)
```regex
(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)
```

--- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.