### PR TITLE
fix deployment config script

### DIFF
--- a/_scripts/configure-deploy.sh
+++ b/_scripts/configure-deploy.sh
@@ -5,7 +5,8 @@ set -e
 # This script expects the following environment variable(s)
 # ASSET_ROLE_ARN: the AWS role ARN that is used to publish assets
 
-cat << EOF > ~/.aws/config
+mkdir -p $HOME/.aws
+cat << EOF > $HOME/.aws/config
 [default]
 output = json
 
@@ -14,4 +15,4 @@ role_arn = ${ASSET_ROLE_ARN}
 credential_source = Environment
 EOF
 
-cat ~/.aws/config
+cat $HOME/.aws/config


### PR DESCRIPTION
*Description of changes:*
fixes the deployment configuration script - needed to explicitly make the `~/.aws` folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
