### PR TITLE
Remove duplicated Type key from s3 bucket template

### DIFF
--- a/src/templates/aws-genomics-s3.template.yaml
+++ b/src/templates/aws-genomics-s3.template.yaml
@@ -20,7 +20,6 @@ Parameters:
       A S3 bucket name for storing analysis results.
       The bucket name must respect the S3 bucket naming conventions 
       (can contain lowercase letters, numbers, periods and hyphens).
-    Type: String
     AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
     ConstraintDescription: "Must respect AWS naming conventions"
   ExistingBucket:


### PR DESCRIPTION
The `Type: String` seems to be duplicated so getting a YAMLException in the AWS Designer editor.

<img width="1259" alt="Screen Shot 2019-04-01 at 13 26 59" src="https://user-images.githubusercontent.com/29562861/55302669-e9bb5100-548d-11e9-8ec8-e035e2f58a90.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
