### PR TITLE
use sync --delete for deploy

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -7,28 +7,28 @@ mkdocs build
 
 
 echo "publishing artifacts:"
-aws s3 cp \
+aws s3 sync \
     --profile asset-publisher \
     --acl public-read \
-    --recursive \
+    --delete \
     ./artifacts \
     s3://aws-genomics-workflows/artifacts
 
 
 echo "publishing templates:"
-aws s3 cp \
+aws s3 sync \
     --profile asset-publisher \
     --acl public-read \
-    --recursive \
+    --delete \
     --metadata commit=$(git rev-parse HEAD) \
     ./src/templates \
     s3://aws-genomics-workflows/templates
 
 
 echo "publishing site"
-aws s3 cp \
+aws s3 sync \
     --acl public-read \
-    --recursive \
+    --delete \
     ./site \
     s3://docs.opendata.aws/genomics-workflows
 


### PR DESCRIPTION
*Description of changes:*
uses `s3 sync --delete` instead of `s3 cp --recursive` to deploy site and assets.
this will save space by removing unused assets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
