### PR TITLE
Adding DockerImageAndMetadataVolumeSize as a parameter to the launch …

### DIFF
--- a/src/templates/aws-genomics-launch-template.template.yaml
+++ b/src/templates/aws-genomics-launch-template.template.yaml
@@ -34,6 +34,10 @@ Parameters:
     Type: Number
     Default: 20
     Description: The initial size of the scratch volume (GB)
+  DockerImageAndMetadataVolumeSize:
+    Type: Number
+    Default: 75
+    Description: The size of the volume Docker will use for image and metadata storage (GB)
   WorkflowOrchestrator:
     Type: String
     Description: The workflow orchestration engine you will use
@@ -62,7 +66,7 @@ Metadata:
         Parameters:
           - ScratchMountPoint
           - ScratchVolumeSize
-
+          - DockerImageAndMetadataVolumeSize
 Conditions:
   UseCromwell: !Equals [!Ref WorkflowOrchestrator, cromwell]
 
@@ -80,6 +84,12 @@ Resources:
             - Key: solution
               Value: !Ref WorkflowOrchestrator
         BlockDeviceMappings:
+          - Ebs:
+              Encrypted: True
+              DeleteOnTermination: True
+              VolumeSize: !Ref DockerImageAndMetadataVolumeSize
+              VolumeType: gp2 
+            DeviceName: /dev/xvdcz
           - Ebs:
               Encrypted: True
               DeleteOnTermination: True


### PR DESCRIPTION
Added a new parameter DockerImageAndMetadataVolumeSize to the launch template. The 22GB that comes by default is too small.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
