### PR TITLE
fix url to create-custom-compute-resources

### DIFF
--- a/docs/orchestration/cromwell/cromwell-overview.md
+++ b/docs/orchestration/cromwell/cromwell-overview.md
@@ -41,7 +41,7 @@ these setup.
 
 ## Custom Compute Resource with Cromwell Additions
 
-Follow the [instructions on creating a custom compute resources](/core-env/create-custom-compute-resources/) with the following changes:
+Follow the [instructions on creating a custom compute resources](../../../core-env/create-custom-compute-resources/) with the following changes:
 
 * specify the scratch mount point as `/cromwell_root`
 * make sure that cromwell additions are included in the resource by selecting "cromwell" as the resource type.


### PR DESCRIPTION
*Issue #, if available:*
#28 

*Description of changes:*
fixes url to `create-custom-compute-resources` on the Cromwell overview page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
