### PR TITLE
add tagging to batch launched instances

### DIFF
--- a/src/templates/aws-genomics-batch.template.yaml
+++ b/src/templates/aws-genomics-batch.template.yaml
@@ -196,6 +196,9 @@ Resources:
   GenomicsHighPriorityQueue:
     Type: AWS::Batch::JobQueue
     Properties:
+      JobQueueName: !Sub
+        - highpriority-${StackGuid}
+        - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
       Priority: 1000
       State: ENABLED
       ComputeEnvironmentOrder:
@@ -207,6 +210,9 @@ Resources:
   GenomicsDefaultQueue:
     Type: AWS::Batch::JobQueue
     Properties:
+      JobQueueName: !Sub
+        - default-${StackGuid}
+        - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
       Priority: 1
       State: ENABLED
       ComputeEnvironmentOrder:

--- a/src/templates/aws-genomics-batch.template.yaml
+++ b/src/templates/aws-genomics-batch.template.yaml
@@ -139,6 +139,9 @@ Resources:
     Type: AWS::Batch::ComputeEnvironment
     DependsOn: GenomicsBatchSecurityGroup
     Properties:
+      ComputeEnvironmentName: !Sub 
+       - spot-${StackGuid}
+       - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
       ServiceRole: !Ref BatchServiceRoleArn
       Type: MANAGED
       State: ENABLED
@@ -157,11 +160,18 @@ Resources:
         SpotIamFleetRole: !Ref SpotFleetRoleArn
         Subnets: !Ref SubnetIds
         Type: SPOT
+        Tags:
+          Name: !Sub
+            - batch-spot-worker-${StackGuid}
+            - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
 
   GenomicsHighPriorityComputeEnv:
     Type: AWS::Batch::ComputeEnvironment
     DependsOn: GenomicsBatchSecurityGroup
     Properties:
+      ComputeEnvironmentName: !Sub 
+       - ondemand-${StackGuid}
+       - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
       ServiceRole: !Ref BatchServiceRoleArn
       Type: MANAGED
       State: ENABLED
@@ -178,6 +188,10 @@ Resources:
           - !Ref GenomicsBatchSecurityGroup
         Subnets: !Ref SubnetIds
         Type: EC2
+        Tags:
+          Name: !Sub
+            - batch-ondemand-worker-${StackGuid}
+            - StackGuid: !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
 
   GenomicsHighPriorityQueue:
     Type: AWS::Batch::JobQueue


### PR DESCRIPTION
*Issue #, if available:*
#30 

*Description of changes:*
* provide Name tags that allow instances to be quickly identified as
belonging to a specific compute environment in a specific stack
* name compute environments so that they can be quickly identified as
belonging to a specific stack
* name compute environments based on the instances pricing that they
will launch (spot | ondemand)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
