### PR TITLE
make s3 data bucket name optional

### DIFF
--- a/src/templates/aws-genomics-s3.template.yaml
+++ b/src/templates/aws-genomics-s3.template.yaml
@@ -20,7 +20,8 @@ Parameters:
       A S3 bucket name for storing analysis results.
       The bucket name must respect the S3 bucket naming conventions 
       (can contain lowercase letters, numbers, periods and hyphens).
-    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+      If left blank a unique bucket name will be generated.
+    AllowedPattern: "((?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)|(^.{0}$))"
     ConstraintDescription: "Must respect AWS naming conventions"
   ExistingBucket:
     Type: String
@@ -35,6 +36,10 @@ Conditions:
     Fn::Equals:
       - !Ref ExistingBucket
       - No
+  GenerateBucketName:
+    Fn::Equals:
+      - !Ref S3BucketName
+      - ""
 
 Resources:
   GenomicsEnvS3Bucket:
@@ -42,7 +47,14 @@ Resources:
     Condition: BucketDoesNotExist
     DeletionPolicy: Retain
     Properties:
-      BucketName: !Ref S3BucketName
+      BucketName:
+        Fn::If:
+          - GenerateBucketName
+          - Fn::Join: 
+            - "-"
+            - - "genomics-workflows"
+              - !Select [ 2, !Split [ "/", !Ref "AWS::StackId" ]]
+          - !Ref S3BucketName
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/src/templates/cromwell/cromwell-aio.template.yaml
+++ b/src/templates/cromwell/cromwell-aio.template.yaml
@@ -70,11 +70,13 @@ Parameters:
     Type: List<AWS::EC2::AvailabilityZone::Name>
   S3BucketName:
     Description: >-
-      A S3 bucket name for storing analysis results. 
+      A S3 bucket name for storing analysis results.
       The bucket name must respect the S3 bucket naming conventions 
       (can contain lowercase letters, numbers, periods and hyphens).
+      If left blank a unique bucket name will be generated.
+
     Type: String
-    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+    AllowedPattern: "((?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)|(^.{0}$))"
     ConstraintDescription: "Must respect S3 bucket naming conventions"
   ExistingBucket:
     Description: Does this bucket already exist?

--- a/src/templates/nextflow/nextflow-aio.template.yaml
+++ b/src/templates/nextflow/nextflow-aio.template.yaml
@@ -74,9 +74,14 @@ Parameters:
     Description: "Choose the two Availability Zones to deploy instances for AWS Batch."
     Type: List<AWS::EC2::AvailabilityZone::Name>
   S3DataBucketName:
-    Description: A S3 bucket name for storing analysis results
+    Description: >-
+      A S3 bucket name for storing analysis results
+      The bucket name must respect the S3 bucket naming conventions 
+      (can contain lowercase letters, numbers, periods and hyphens).
+      If left blank a unique bucket name will be generated.
+
     Type: String
-    AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
+    AllowedPattern: "((?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)|(^.{0}$))"
     ConstraintDescription: "Must respect S3 bucket naming conventions"
   ExistingDataBucket:
     Description: Does this bucket already exist?

--- a/src/templates/step-functions/sfn-aio.template.yaml
+++ b/src/templates/step-functions/sfn-aio.template.yaml
@@ -65,9 +65,10 @@ Parameters:
     Type: List<AWS::EC2::AvailabilityZone::Name>
   S3BucketName:
     Description: >-
-      A S3 bucket name for storing analysis results. 
+      A S3 bucket name for storing analysis results.
       The bucket name must respect the S3 bucket naming conventions 
       (can contain lowercase letters, numbers, periods and hyphens).
+      If left blank a unique bucket name will be generated.
     Type: String
     AllowedPattern: "(?=^.{3,63}$)(?!^(\\d+\\.)+\\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$)"
     ConstraintDescription: "Must respect S3 bucket naming conventions"


### PR DESCRIPTION
*Description of changes:*
Makes supplying the primary bucket name optional.  If left blank, a unique name is generated.  Users can still supply a name that they prefer that complies with S3 bucket naming rules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
