### PR TITLE
Add EXIT trap to nextflow entrypoint script

### DIFF
--- a/docs/orchestration/nextflow/nextflow-overview.md
+++ b/docs/orchestration/nextflow/nextflow-overview.md
@@ -108,7 +108,7 @@ cd /opt/work/$GUID
 aws s3 sync --only-show-errors $NF_LOGSDIR/.nextflow .nextflow
 
 # stage workflow definition
-if [[ "$NEXTFLOW_PROJECT" =~ "^s3://.*" ]]; then
+if [[ "$NEXTFLOW_PROJECT" =~ ^s3://.* ]]; then
     aws s3 sync --only-show-errors --exclude 'runs/*' --exclude '.*' $NEXTFLOW_PROJECT ./project
     NEXTFLOW_PROJECT=./project
 fi

--- a/src/containers/nextflow/nextflow.aws.sh
+++ b/src/containers/nextflow/nextflow.aws.sh
@@ -51,7 +51,7 @@ cd /opt/work/$GUID
 aws s3 sync --only-show-errors $NF_LOGSDIR/.nextflow .nextflow
 
 # stage workflow definition
-if [[ "$NEXTFLOW_PROJECT" =~ "^s3://.*" ]]; then
+if [[ "$NEXTFLOW_PROJECT" =~ ^s3://.* ]]; then
     aws s3 sync --only-show-errors --exclude 'runs/*' --exclude '.*' $NEXTFLOW_PROJECT ./project
     NEXTFLOW_PROJECT=./project
 fi


### PR DESCRIPTION
*Description of changes:*

Adds an EXIT signal trap to the nextflow container entrypoint script so that workflows that fail emit the correct exit code to Batch but also still preserve the session cache.

Also adds corresponding updates to the docs along with:
* add shebang to docs listing so that folks building from scratch don't omit this
* add additional logging text to stdout to monitor script execution path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
