### PR TITLE
auto expanding docker data volume fixes

### DIFF
--- a/src/templates/nextflow/nextflow-aio.template.yaml
+++ b/src/templates/nextflow/nextflow-aio.template.yaml
@@ -215,7 +215,7 @@ Outputs:
   NextflowContainerImage:
     Value: !GetAtt NextflowStack.Outputs.NextflowContainerImage
     Export:
-      Name: !Sub "${AWS::StackName}-NextflowJobDefinition"
+      Name: !Sub "${AWS::StackName}-NextflowContainerImage"
     
   NextflowJobDefinition:
     Value: !GetAtt NextflowStack.Outputs.NextflowJobDefinition


### PR DESCRIPTION
*Description of changes:*

* explicitly stop ecs before starting ebs autoscale on /var/lib/docker
* move nextflow additions to before start ecs
* add steps missing that are documented here: https://docs.docker.com/storage/storagedriver/btrfs-driver/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
