### PR TITLE
Copy ebs scripts to /usr/bin

### DIFF
--- a/src/ebs-autoscale/bin/init-ebs-autoscale.sh
+++ b/src/ebs-autoscale/bin/init-ebs-autoscale.sh
@@ -47,8 +47,8 @@ RG=$(echo ${AZ} | sed -e 's/[a-z]$//')
 IN=$(curl -s  http://169.254.169.254/latest/meta-data/instance-id)
 BASEDIR=$(dirname $0)
 
-# copy the binaries to /usr/local/bin
-cp ${BASEDIR}/{create-ebs-volume.py,ebs-autoscale} /usr/local/bin/
+# copy the binaries to /usr/bin
+cp ${BASEDIR}/{create-ebs-volume.py,ebs-autoscale} /usr/bin
 
 # If a device is not given, or if the device is not valid
 # create a new 20GB volume


### PR DESCRIPTION
Using `/usr/bin` instead of `/usr/local/bin` because the latter is not on the default PATH 
for the root user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
