### PR TITLE
Add s3:GetObject permission to EC2 instance role

### DIFF
--- a/src/templates/cromwell/cromwell-server.template.yaml
+++ b/src/templates/cromwell/cromwell-server.template.yaml
@@ -142,7 +142,7 @@ Resources:
                 Action:
                   - "s3:ListBucket"
                   - "s3:ListAllMyBuckets"
-
+                  - "s3:GetObject"
         
         - PolicyName: !Sub CromwellServer-CloudWatch-Access-${AWS::Region}
           PolicyDocument:


### PR DESCRIPTION
Let's add the s3:GetObject permission to EC2 instance role for retrieving objects from S3 buckets and open datasets.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
