### PR TITLE
Add AWS-managed ssm policy to Ec2InstanceRole

### DIFF
--- a/docs/orchestration/cromwell/cromwell-overview.md
+++ b/docs/orchestration/cromwell/cromwell-overview.md
@@ -210,6 +210,8 @@ This value can also be supplied as a Java command line variable.
 
 ### Accessing the Cromwell server
 
+The Cromwell EC2 instance may be accessed using the [AWS Session Manager](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/session-manager.html). Please note that by default this will log you in as user `ec2-user` in the directory `/usr/bin`. You may prefer to become the ec2-user with the command `sudo su - ec2-user` which will switch you to that user's home directory.
+
 ### Stop / Start / Restart the Cromwell service
 
 The CloudFormation template above installs Cromwell as a service under the control of `supervisorctl`. If you need to make changes to the `cromwell.conf` file you will want to restart the service so that configuration changes are included.

--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -222,6 +222,8 @@ Resources:
   Ec2InstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       Policies:
         - PolicyName: !Sub CromwellServer-BatchQueue-Access-${AWS::Region}
           PolicyDocument:


### PR DESCRIPTION
*Issue #, if available:*
#120

*Description of changes:*
Add the AWS-managed policy `AmazonSSMManagedInstanceCore` to the EC2InstanceRole. This is necessary to make Session Manager connection work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
