### PR TITLE
Set ECS option to pull docker images only if the image is missing

### DIFF
--- a/src/templates/gwfcore/gwfcore-launch-template.template.yaml
+++ b/src/templates/gwfcore/gwfcore-launch-template.template.yaml
@@ -121,6 +121,9 @@ Resources:
                 # enable ecs spot instance draining
                 - echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
 
+                # pull docker images only if missing
+                - echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
+
                 - cd /opt
                 - aws s3 sync $INSTALLED_ARTIFACTS_S3_ROOT_URL/ecs-additions ./ecs-additions
                 - chmod a+x /opt/ecs-additions/provision.sh


### PR DESCRIPTION
*Issue #, if available:*
#122

*Description of changes:*
This simply sets an environment variable which will instruct amazon-ecs-agent to only pull images if they are missing from the local cache.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
