### PR TITLE
Ship logs to cloudwatch to diagnose provisioning errors

### DIFF
--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -257,6 +257,12 @@ Resources:
         - Order: 2
           ComputeEnvironment: !Ref OnDemandComputeEnv
 
+  ContainerInstanceLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/aws/ecs/container-instance"
+      RetentionInDays: 7
+
 Outputs:
   DefaultJobQueueArn:
     Value: !Ref DefaultQueue

--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -128,6 +128,8 @@ Resources:
       Type: MANAGED
       State: ENABLED
       ComputeResources:
+        Ec2Configuration:
+          - ImageType: ECS_AL2
         AllocationStrategy: SPOT_CAPACITY_OPTIMIZED
         # Set the Spot price to 100% of on-demand price
         # This is the maximum price for spot instances that Batch will launch.

--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -262,7 +262,7 @@ Resources:
   ContainerInstanceLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "/aws/ecs/container-instance"
+      LogGroupName: "/aws/ecs/container-instance/${Namespace}"
       RetentionInDays: 7
 
 Outputs:

--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -262,7 +262,7 @@ Resources:
   ContainerInstanceLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "/aws/ecs/container-instance/${Namespace}"
+      LogGroupName: !Sub "/aws/ecs/container-instance/${Namespace}"
       RetentionInDays: 7
 
 Outputs:

--- a/src/templates/gwfcore/gwfcore-iam.template.yaml
+++ b/src/templates/gwfcore/gwfcore-iam.template.yaml
@@ -129,6 +129,7 @@ Resources:
       - "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
       - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
       - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   BatchInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/src/templates/gwfcore/gwfcore-launch-template.template.yaml
+++ b/src/templates/gwfcore/gwfcore-launch-template.template.yaml
@@ -107,55 +107,55 @@ Resources:
                 - unzip
                 - amazon-cloudwatch-agent
 
-                runcmd:
-
-                # create the amazon-cloudwatch-agent config file
-                - |
-                  cat > /opt/aws/amazon-cloudwatch-agent/etc/config.json <<- EOF
-                  {
-                    "agent": {
-                      "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
-                    },
-                    "logs": {
-                      "logs_collected": {
-                        "files": {
-                          "collect_list": [
-                            {
-                              "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/amazon-cloudwatch-agent.log"
-                            },
-                            {
-                              "file_path": "/var/log/cloud-init.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/cloud-init.log"
-                            },
-                            {
-                              "file_path": "/var/log/cloud-init-output.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/cloud-init-output.log"
-                            },
-                            {
-                              "file_path": "/var/log/ecs/ecs-init.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-init.log"
-                            },
-                            {
-                              "file_path": "/var/log/ecs/ecs-agent.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-agent.log"
-                            },
-                            {
-                              "file_path": "/var/log/ecs/ecs-volume-plugin.log",
-                              "log_group_name": "/aws/ecs/container-instance",
-                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-volume-plugin.log"
-                            }
-                          ]
+                write_files:
+                - permissions: '0644'
+                  path: /opt/aws/amazon-cloudwatch-agent/etc/config.json
+                  content: |
+                    {
+                      "agent": {
+                        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+                      },
+                      "logs": {
+                        "logs_collected": {
+                          "files": {
+                            "collect_list": [
+                              {
+                                "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/amazon-cloudwatch-agent.log"
+                              },
+                              {
+                                "file_path": "/var/log/cloud-init.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/cloud-init.log"
+                              },
+                              {
+                                "file_path": "/var/log/cloud-init-output.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/cloud-init-output.log"
+                              },
+                              {
+                                "file_path": "/var/log/ecs/ecs-init.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/ecs-init.log"
+                              },
+                              {
+                                "file_path": "/var/log/ecs/ecs-agent.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/ecs-agent.log"
+                              },
+                              {
+                                "file_path": "/var/log/ecs/ecs-volume-plugin.log",
+                                "log_group_name": "/aws/ecs/container-instance/${Namespace}",
+                                "log_stream_name": "/aws/ecs/container-instance/${Namespace}/{instance_id}/ecs-volume-plugin.log"
+                              }
+                            ]
+                          }
                         }
                       }
                     }
-                  }
-                  EOF
+
+                runcmd:
 
                 # start the amazon-cloudwatch-agent
                 - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json

--- a/src/templates/gwfcore/gwfcore-launch-template.template.yaml
+++ b/src/templates/gwfcore/gwfcore-launch-template.template.yaml
@@ -96,7 +96,7 @@ Resources:
 
                 #cloud-config
                 repo_update: true
-                repo_upgrade: all
+                repo_upgrade: security
 
                 packages:
                 - jq

--- a/src/templates/gwfcore/gwfcore-launch-template.template.yaml
+++ b/src/templates/gwfcore/gwfcore-launch-template.template.yaml
@@ -94,6 +94,10 @@ Resources:
                 --==BOUNDARY==
                 Content-Type: text/cloud-config; charset="us-ascii"
 
+                #cloud-config
+                repo_update: true
+                repo_upgrade: all
+
                 packages:
                 - jq
                 - btrfs-progs
@@ -101,8 +105,61 @@ Resources:
                 - git
                 - amazon-ssm-agent
                 - unzip
+                - amazon-cloudwatch-agent
 
                 runcmd:
+
+                # create the amazon-cloudwatch-agent config file
+                - |
+                  cat > /opt/aws/amazon-cloudwatch-agent/etc/config.json <<- EOF
+                  {
+                    "agent": {
+                      "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+                    },
+                    "logs": {
+                      "logs_collected": {
+                        "files": {
+                          "collect_list": [
+                            {
+                              "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/amazon-cloudwatch-agent.log"
+                            },
+                            {
+                              "file_path": "/var/log/cloud-init.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/cloud-init.log"
+                            },
+                            {
+                              "file_path": "/var/log/cloud-init-output.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/cloud-init-output.log"
+                            },
+                            {
+                              "file_path": "/var/log/ecs/ecs-init.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-init.log"
+                            },
+                            {
+                              "file_path": "/var/log/ecs/ecs-agent.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-agent.log"
+                            },
+                            {
+                              "file_path": "/var/log/ecs/ecs-volume-plugin.log",
+                              "log_group_name": "/aws/ecs/container-instance",
+                              "log_stream_name": "/aws/ecs/container-instance/{instance_id}/ecs-volume-plugin.log"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                  EOF
+
+                # start the amazon-cloudwatch-agent
+                - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+
                 # install aws-cli v2 and copy the static binary in an easy to find location for bind-mounts into containers
                 - curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
                 - unzip -q /tmp/awscliv2.zip -d /tmp


### PR DESCRIPTION
*Issue #, if available:*
This PR will help in debugging #114 (or similar provisioning problems), but it is not a solution for the issue.

*Description of changes:*
The purpose of this change is to copy to Cloudwatch logs from container instances which are ephemeral. The problem with troubleshooting provisioning errors is that we currently don't have any insight into what went wrong since we can't see the instance logs. This picks just a few of the logs we'll likely need, and persist those in their own Cloudwatch log group for one week, which should be enough time to investigate an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
