### PR TITLE
Fixed issue when running aws cli v2 on minimal docker instances (erro…

### DIFF
--- a/src/containers/nextflow/nextflow.aws.sh
+++ b/src/containers/nextflow/nextflow.aws.sh
@@ -45,6 +45,7 @@ workDir = "$NF_WORKDIR"
 process.executor = "awsbatch"
 process.queue = "$NF_JOB_QUEUE"
 aws.batch.cliPath = "$AWS_CLI_PATH"
+env.LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/aws-cli/bin"
 EOF
 
 echo "=== CONFIGURATION ==="
@@ -52,7 +53,7 @@ cat ./nextflow.config
 
 # stage in session cache
 # .nextflow directory holds all session information for the current and past runs.
-# it should be `sync`'d with an s3 uri, so that runs from previous sessions can be 
+# it should be `sync`'d with an s3 uri, so that runs from previous sessions can be
 # resumed
 echo "== Restoring Session Cache =="
 aws s3 sync --no-progress $NF_LOGSDIR/.nextflow .nextflow

--- a/src/containers/nextflow/nextflow.aws.sh
+++ b/src/containers/nextflow/nextflow.aws.sh
@@ -45,7 +45,6 @@ workDir = "$NF_WORKDIR"
 process.executor = "awsbatch"
 process.queue = "$NF_JOB_QUEUE"
 aws.batch.cliPath = "$AWS_CLI_PATH"
-env.LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/aws-cli/bin"
 EOF
 
 echo "=== CONFIGURATION ==="

--- a/src/ecs-additions/fetch_and_run.sh
+++ b/src/ecs-additions/fetch_and_run.sh
@@ -16,6 +16,7 @@
 # See below for usage instructions.
 
 #PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/aws-cli/v2/current/dist
 BASENAME="${0##*/}"
 AWS="/usr/local/aws-cli/v2/current/bin/aws"
 


### PR DESCRIPTION
…r: missing libz.so.1). Note: aws help broken (due to missing 'groff')

By default, the aws cli zip package contains the shared object files (.so) in the distribution folder. Setting LD_LIBRARY_PATH to this dist directory will allow the aws cli to run on instances without this shared library. Tested on a minimal biocontainer instance.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
