### PR TITLE
enable awscli-v2 for containers w/o glibc

### DIFF
--- a/src/ecs-additions/awscli-shim.sh
+++ b/src/ecs-additions/awscli-shim.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This shim is for using the AWS ClI v2 with containers that do not have full glibc
+# it makes the shared libraries the AWS CLI v2 findable via LD_LIBRARY_PATH
+#
+# expect to be installed as /opt/aws-cli/bin/aws
+# expect to actually call /opt/aws-cli/dist/aws
+# expect that /opt/aws-cli is mapped to containers
+
+BIN_DIR=`dirname $0`
+DIST_DIR=`dirname $BIN_DIR`/dist
+AWS=$DIST_DIR/aws
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DIST_DIR
+
+$AWS $@
+

--- a/src/ecs-additions/ecs-additions-common.sh
+++ b/src/ecs-additions/ecs-additions-common.sh
@@ -3,3 +3,10 @@
 # add fetch and run batch helper script
 chmod a+x /opt/ecs-additions/fetch_and_run.sh
 cp /opt/ecs-additions/fetch_and_run.sh /usr/local/bin
+
+# add awscli-shim
+mv /opt/aws-cli/bin /opt/aws-cli/dist
+chmod a+x /opt/ecs-additions/awscli-shim.sh
+mkdir /opt/aws-cli/bin
+cp /opt/ecs-additions/awscli-shim.sh /opt/aws-cli/bin/aws
+


### PR DESCRIPTION
*Description of changes:*
Adds a shim that sets LD_LIBRARY_PATH when calling AWS CLI v2. This enables compatibility with containers built using images that lack `glibc`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
