### PR TITLE
Copying shim to /usr/local/aws-cli (default cromwell path) to avoid s…

### DIFF
--- a/src/ecs-additions/ecs-additions-common.sh
+++ b/src/ecs-additions/ecs-additions-common.sh
@@ -8,7 +8,11 @@ cp /opt/ecs-additions/fetch_and_run.sh /usr/local/bin
 mv /opt/aws-cli/bin /opt/aws-cli/dist
 chmod a+x /opt/ecs-additions/awscli-shim.sh
 mkdir /opt/aws-cli/bin
-cp /opt/ecs-additions/awscli-shim.sh /opt/aws-cli/bin/aws
+cp /opt/ecs-additions/awscli-shim.sh /opt/aws-cli/bin/aws                  # Used in Nextflow
+
+# Remove current symlink
+rm -f /usr/local/aws-cli/v2/current/bin/aws
+cp /opt/ecs-additions/awscli-shim.sh /usr/local/aws-cli/v2/current/bin/aws # Used in Cromwell
 
 # add 4GB of swap space
 dd if=/dev/zero of=/swapfile bs=128M count=32

--- a/src/ecs-additions/fetch_and_run.sh
+++ b/src/ecs-additions/fetch_and_run.sh
@@ -16,7 +16,6 @@
 # See below for usage instructions.
 
 #PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/aws-cli/v2/current/dist
 BASENAME="${0##*/}"
 AWS="/usr/local/aws-cli/v2/current/bin/aws"
 


### PR DESCRIPTION
…etting LD_LIBRARY_PATH globally in fetch_and_run script. Issue: 135

*Issue #, if available:*
Issue 135

*Description of changes:*
Removed exporting LD_LIBRARY_PATH in fetch_and_run.sh script and copying "awscli-shim.sh" to /usr/local/aws-cli/v2/current/bin/aws (which is the path called by fetch_and_run and also from within the cromwell AWS Batch backend). This allows us to set the LD_LIBRARY_PATH when calling the aws cli and should not effect the global environment within the container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
