### PR TITLE
run get_cromwell_tools

### DIFF
--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -332,6 +332,7 @@ Resources:
             - config1
             - config2
             - config3
+            - config4
 
         config1:
           files:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- forget to add config4 to cfn-init, so `get_cromwell_tools.sh` was not running

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
