### PR TITLE
Assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,18 @@ script:
 before_deploy:
 
   - pip install awscli --upgrade
-  - bash _scripts/configure-deploy.sh
+  - bash _scripts/configure-deploy.sh --clobber
 
 deploy:
   - provider: script
-    script: bash _scripts/deploy.sh --verbose production
+    script: bash _scripts/deploy.sh --public --verbose production
     skip_cleanup: true
     on:
       repo: aws-samples/aws-genomics-workflows
       branch: release
       tags: true
   - provider: script
-    script: bash _scripts/deploy.sh --verbose test
+    script: bash _scripts/deploy.sh --public --verbose test
     skip_cleanup: true
     on:
       repo: aws-samples/aws-genomics-workflows

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,14 @@ before_deploy:
 
 deploy:
   - provider: script
-    script: bash _scripts/deploy.sh production
+    script: bash _scripts/deploy.sh --verbose production
     skip_cleanup: true
     on:
       repo: aws-samples/aws-genomics-workflows
       branch: release
       tags: true
   - provider: script
-    script: bash _scripts/deploy.sh test
+    script: bash _scripts/deploy.sh --verbose test
     skip_cleanup: true
     on:
       repo: aws-samples/aws-genomics-workflows

--- a/_scripts/configure-deploy.sh
+++ b/_scripts/configure-deploy.sh
@@ -1,9 +1,59 @@
 #!/bin/bash
 
+# Create a default ~/.aws/configure file for Travis testing
+
 set -e
 
 # This script expects the following environment variable(s)
 # ASSET_ROLE_ARN: the AWS role ARN that is used to publish assets
+
+usage() {
+    cat <<EOM
+    Usage:
+    $(basename $0) [--clobber]
+
+    --clobber  Overwrite ~/.aws/configure file without asking
+EOM
+}
+
+CLOBBER=''
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --clobber)
+            CLOBBER=1
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        --) # end optional argument parsing
+            shift
+            break
+            ;;
+        -*|--*=)
+            echo "Error: unsupported argument $1" >&2
+            exit 1
+            ;;
+        *) # positional agruments
+            PARAMS="$PARAMS $1"
+            shift
+            ;;
+    esac
+done
+eval set -- "$PARAMS"
+
+if [ -z $CLOBBER ]; then
+    while true; do
+        read -p "Overwrite ~/.aws/config file [y/n]? " yn
+        case $yn in
+            [Yy]* ) CLOBBER=1; break;;
+            [Nn]* ) echo "Exiting"; exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+fi
 
 mkdir -p $HOME/.aws
 cat << EOF > $HOME/.aws/config

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -77,6 +77,7 @@ function s3_sync() {
     cmd="aws s3 sync \
         --profile $ASSET_PROFILE \
         --region $DEPLOY_REGION \
+        --acl public-read \
         --delete \
         --metadata commit=$(git rev-parse HEAD) \
         $source \

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -2,9 +2,10 @@
 
 set -e
 
-bash _scripts/make-dist.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+bash ${DIR}/make-dist.sh
 mkdocs build
-
+exit
 SITE_BUCKET=s3://docs.opendata.aws/genomics-workflows
 ASSET_BUCKET=s3://aws-genomics-workflows
 ASSET_STAGE=test
@@ -44,7 +45,6 @@ while (( "$#" )); do
             ;;
     esac
 done
-
 eval set -- "$PARAMS"
 
 ASSET_STAGE=${1:-$ASSET_STAGE}

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -107,7 +107,6 @@ function s3_sync() {
         $destination"
     echo $cmd
     eval $cmd
-    exit
 }
 
 function publish() {
@@ -158,11 +157,12 @@ function pin_version() {
     local version=$1
     local asset=$2
     local folder=$3
-
+    
     echo "PINNING VERSIONS"
     for file in `grep -irl "$asset  # dist: pin_version" $folder`; do
         echo "pinning '$asset' as '$version/$asset' in '$file'"
-        sed -i'' -e "s|$asset  # dist: pin_version|$version/$asset  #|g" $file
+        sed -e "s|$asset  # dist: pin_version|$version/$asset  #|g" $file > $file.tmp
+        mv $file.tmp $file
     done
 }
 

--- a/_scripts/make-dist.sh
+++ b/_scripts/make-dist.sh
@@ -1,5 +1,39 @@
 #!/bin/bash
 
+# make-dist.sh: Create distribution artifacts
+# This script is expected to be in a subdirectory of the top-level directory
+# It accesses the subdirectory 'src', and creates a subdirectory 'dist', in the top-level directory:
+#    .
+#    |-_scripts
+#    |---make-dist.sh
+#    |-dist
+#    |-src
+
+
+VERBOSE=""
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --verbose)
+            VERBOSE='-v'
+            shift
+            ;;
+        --) # end optional argument parsing
+            shift
+            break
+            ;;
+        -*|--*=)
+            echo "Error: unsupported argument $1" >&2
+            exit 1
+            ;;
+        *) # positional agruments
+            PARAMS="$PARAMS $1"
+            shift
+            ;;
+    esac
+done
+eval set -- "$PARAMS"
+
 echo "checking for dependencies"
 
 DEPENDENCIES=$(cat <<EOF
@@ -25,12 +59,14 @@ done
 set -e
 
 CWD=`pwd`
-SOURCE_PATH=${CWD}/src
-DIST_PATH=${CWD}/dist
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+INSTALL_DIR=`dirname $DIR`
+SOURCE_PATH=$INSTALL_DIR/src
+DIST_PATH=$INSTALL_DIR/dist
 
-TEMP_PATH=${DIST_PATH}/tmp
-ARTIFACT_PATH=${DIST_PATH}/artifacts
-TEMPLATES_PATH=${DIST_PATH}/templates
+TEMP_PATH=$DIST_PATH/tmp
+ARTIFACT_PATH=$DIST_PATH/artifacts
+TEMPLATES_PATH=$DIST_PATH/templates
 
 if [ ! -d $DIST_PATH ]; then
     mkdir -p $DIST_PATH
@@ -39,11 +75,10 @@ fi
 cd $DIST_PATH
 
 # clean up previous dist build
-echo "removing previous dist"
-rm -rf ./*
+echo "removing previous dist in $DIST_PATH"
+[ ! -z $DIR ] && rm -rf $DIST_PATH/*
 
-for d in $TEMP_PATH $ARTIFACT_PATH $TEMPLATES_PATH;
-do
+for d in $TEMP_PATH $ARTIFACT_PATH $TEMPLATES_PATH; do
     if [ ! -d $d ];
     then
         echo "creating $d"
@@ -55,69 +90,75 @@ done
 # combines the latest release of amazon-ebs-autoscale with compatibility shim
 # scripts in ./ebs-autoscale/
 echo "packaging amazon-ebs-autoscale"
-cd ${TEMP_PATH}
+cd $TEMP_PATH
 
 EBS_AUTOSCALE_VERSION=$(curl --silent "https://api.github.com/repos/awslabs/amazon-ebs-autoscale/releases/latest" | jq -r .tag_name)
 curl --silent -L \
     "https://github.com/awslabs/amazon-ebs-autoscale/archive/${EBS_AUTOSCALE_VERSION}.tar.gz" \
     -o ./amazon-ebs-autoscale.tar.gz 
 
-tar -xzvf ./amazon-ebs-autoscale.tar.gz
+echo "copying `tar -tzf ./amazon-ebs-autoscale.tar.gz | wc -l` files from ebs-autoscale $EBS_AUTOSCALE_VERSION into tmp/amazon-ebs-autoscale/"
+tar $VERBOSE -xzf ./amazon-ebs-autoscale.tar.gz
 mv ./amazon-ebs-autoscale*/ ./amazon-ebs-autoscale
 echo $EBS_AUTOSCALE_VERSION > ./amazon-ebs-autoscale/VERSION
 
-cp -Rfv $SOURCE_PATH/ebs-autoscale .
-cp -Rfv ./amazon-ebs-autoscale/* ./ebs-autoscale/
-
-tar -czvf ${ARTIFACT_PATH}/aws-ebs-autoscale.tgz ./ebs-autoscale/
+echo "copying src/ebs-autoscale with `find $SOURCE_PATH/ebs-autoscale/ -type f | wc -l` files to tmp/"
+cp $VERBOSE -Rf $SOURCE_PATH/ebs-autoscale .
+echo "copying `find amazon-ebs-autoscale -type f | wc -l` files from tmp/amazon-ebs-autoscale/ to tmp/ebs-autoscale/"
+cp $VERBOSE -Rf ./amazon-ebs-autoscale/* ./ebs-autoscale/
+echo "creating artifacts/aws-ebs-autoscale.tgz with `find ./ebs-autoscale/ -type f | wc -l` files from tmp/ebs-autoscale/"
+tar $VERBOSE -czf $ARTIFACT_PATH/aws-ebs-autoscale.tgz ./ebs-autoscale/
 
 # add a copy of the release tarball for naming consistency
-tar -czvf ${ARTIFACT_PATH}/amazon-ebs-autoscale.tgz ./amazon-ebs-autoscale
+echo "creating artifacts/amazon-ebs-autoscale.tgz with `find ./amazon-ebs-autoscale/ -type f | wc -l` files from tmp/amazon-ebs-autoscale/"
+tar $VERBOSE -czf $ARTIFACT_PATH/amazon-ebs-autoscale.tgz ./amazon-ebs-autoscale
 
 # add a retrieval script
-cp -vf ${SOURCE_PATH}/ebs-autoscale/get-amazon-ebs-autoscale.sh ${ARTIFACT_PATH}
+cp $VERBOSE -f $SOURCE_PATH/ebs-autoscale/get-amazon-ebs-autoscale.sh $ARTIFACT_PATH
 
 # package crhelper lambda(s)
-cd ${SOURCE_PATH}/lambda
+cd $SOURCE_PATH/lambda
 for fn in `ls .`; do
     echo "packaging crhelper lambda $fn"
-    mkdir -p ${TEMP_PATH}/lambda/$fn
-    cp -Rv ${SOURCE_PATH}/lambda/$fn/. ${TEMP_PATH}/lambda/$fn
+    mkdir -p $TEMP_PATH/lambda/$fn
+    cp $VERBOSE -R $SOURCE_PATH/lambda/$fn/. $TEMP_PATH/lambda/$fn
 
-    cd ${TEMP_PATH}/lambda/$fn
-    pip install -t . -r requirements.txt
-    zip -r -v $ARTIFACT_PATH/lambda-$fn.zip .
+    cd $TEMP_PATH/lambda/$fn
+    [ -z $VERBOSE ] && P_QUIET='--quiet' || P_QUIET=''
+    pip $P_QUIET install -t . -r requirements.txt
+    echo "creating artifacts/lambda-${fn}.zip with `find . -type f | wc -l` files"
+    [ -z $VERBOSE ] && Z_QUIET='-q' || Z_QUIET=''
+    zip $Z_QUIET -r $ARTIFACT_PATH/lambda-$fn.zip .
 done
-
 
 # package ecs-additions
 echo "packaging ecs-additions"
 
-cd ${TEMP_PATH}
-mkdir -p ${TEMP_PATH}/ecs-additions
-cp -Rv ${SOURCE_PATH}/ecs-additions/. ${TEMP_PATH}/ecs-additions
+cd $TEMP_PATH
+mkdir -p $TEMP_PATH/ecs-additions
+cp $VERBOSE -R $SOURCE_PATH/ecs-additions/. $TEMP_PATH/ecs-additions
 
 # add the amazon-ebs-autoscale retrieval script to additions
-cp -v ${SOURCE_PATH}/ebs-autoscale/get-amazon-ebs-autoscale.sh ${TEMP_PATH}/ecs-additions
+cp $VERBOSE $SOURCE_PATH/ebs-autoscale/get-amazon-ebs-autoscale.sh $TEMP_PATH/ecs-additions
 
 # keep tarball for backwards compatibilty
-cd ${TEMP_PATH}
-tar -czvf ${ARTIFACT_PATH}/aws-ecs-additions.tgz ./ecs-additions/
+cd $TEMP_PATH
+tar $VERBOSE -czf $ARTIFACT_PATH/aws-ecs-additions.tgz ./ecs-additions/
 
 # zip file for codecommit repo
-cd ${TEMP_PATH}/ecs-additions/
-zip -r -v ${ARTIFACT_PATH}/aws-ecs-additions.zip ./*
+cd $TEMP_PATH/ecs-additions/
+zip $Z_QUIET -r $ARTIFACT_PATH/aws-ecs-additions.zip ./*
 
 
 # package container code
-echo "packaging container definitions"
+echo "packaging container definitions with `find $SOURCE_PATH/containers -type f | wc -l` files"
 cd $SOURCE_PATH/containers
-zip -r -v $ARTIFACT_PATH/containers.zip ./*
+zip $Z_QUIET -r $ARTIFACT_PATH/containers.zip ./*
 
 
 # add templates to dist
-echo "copying cloudformation templates"
-cp -Rv $SOURCE_PATH/templates/. $TEMPLATES_PATH
+echo "copying `find $SOURCE_PATH/templates/ -type f | wc -l` cloudformation templates"
+cp $VERBOSE -R $SOURCE_PATH/templates/. $TEMPLATES_PATH
 
 
 # cleanup

--- a/_scripts/make-dist.sh
+++ b/_scripts/make-dist.sh
@@ -92,7 +92,12 @@ done
 echo "packaging amazon-ebs-autoscale"
 cd $TEMP_PATH
 
-EBS_AUTOSCALE_VERSION=$(curl --silent "https://api.github.com/repos/awslabs/amazon-ebs-autoscale/releases/latest" | jq -r .tag_name)
+RESPONSE=$(curl --silent "https://api.github.com/repos/awslabs/amazon-ebs-autoscale/releases/latest")
+EBS_AUTOSCALE_VERSION=$(echo $RESPONSE | jq -r .tag_name)
+if [[ $EBS_AUTOSCALE_VERSION = 'null' ]]; then
+    echo "ERROR: $RESPONSE"
+    exit 1
+fi
 curl --silent -L \
     "https://github.com/awslabs/amazon-ebs-autoscale/archive/${EBS_AUTOSCALE_VERSION}.tar.gz" \
     -o ./amazon-ebs-autoscale.tar.gz 

--- a/_scripts/make-dist.sh
+++ b/_scripts/make-dist.sh
@@ -60,7 +60,7 @@ set -e
 
 CWD=`pwd`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-INSTALL_DIR=`dirname $DIR`
+INSTALL_DIR=$(dirname $DIR)
 SOURCE_PATH=$INSTALL_DIR/src
 DIST_PATH=$INSTALL_DIR/dist
 
@@ -97,20 +97,20 @@ curl --silent -L \
     "https://github.com/awslabs/amazon-ebs-autoscale/archive/${EBS_AUTOSCALE_VERSION}.tar.gz" \
     -o ./amazon-ebs-autoscale.tar.gz 
 
-echo "copying `tar -tzf ./amazon-ebs-autoscale.tar.gz | wc -l` files from ebs-autoscale $EBS_AUTOSCALE_VERSION into tmp/amazon-ebs-autoscale/"
+echo "copying $(tar -tzf ./amazon-ebs-autoscale.tar.gz | wc -l) files from ebs-autoscale $EBS_AUTOSCALE_VERSION into tmp/amazon-ebs-autoscale/"
 tar $VERBOSE -xzf ./amazon-ebs-autoscale.tar.gz
 mv ./amazon-ebs-autoscale*/ ./amazon-ebs-autoscale
 echo $EBS_AUTOSCALE_VERSION > ./amazon-ebs-autoscale/VERSION
 
-echo "copying src/ebs-autoscale with `find $SOURCE_PATH/ebs-autoscale/ -type f | wc -l` files to tmp/"
+echo "copying src/ebs-autoscale with $(find $SOURCE_PATH/ebs-autoscale/ -type f | wc -l) files to tmp/"
 cp $VERBOSE -Rf $SOURCE_PATH/ebs-autoscale .
-echo "copying `find amazon-ebs-autoscale -type f | wc -l` files from tmp/amazon-ebs-autoscale/ to tmp/ebs-autoscale/"
+echo "copying $(find amazon-ebs-autoscale -type f | wc -l) files from tmp/amazon-ebs-autoscale/ to tmp/ebs-autoscale/"
 cp $VERBOSE -Rf ./amazon-ebs-autoscale/* ./ebs-autoscale/
-echo "creating artifacts/aws-ebs-autoscale.tgz with `find ./ebs-autoscale/ -type f | wc -l` files from tmp/ebs-autoscale/"
+echo "creating artifacts/aws-ebs-autoscale.tgz with $(find ./ebs-autoscale/ -type f | wc -l) files from tmp/ebs-autoscale/"
 tar $VERBOSE -czf $ARTIFACT_PATH/aws-ebs-autoscale.tgz ./ebs-autoscale/
 
 # add a copy of the release tarball for naming consistency
-echo "creating artifacts/amazon-ebs-autoscale.tgz with `find ./amazon-ebs-autoscale/ -type f | wc -l` files from tmp/amazon-ebs-autoscale/"
+echo "creating artifacts/amazon-ebs-autoscale.tgz with $(find ./amazon-ebs-autoscale/ -type f | wc -l) files from tmp/amazon-ebs-autoscale/"
 tar $VERBOSE -czf $ARTIFACT_PATH/amazon-ebs-autoscale.tgz ./amazon-ebs-autoscale
 
 # add a retrieval script
@@ -126,7 +126,7 @@ for fn in `ls .`; do
     cd $TEMP_PATH/lambda/$fn
     [ -z $VERBOSE ] && P_QUIET='--quiet' || P_QUIET=''
     pip $P_QUIET install -t . -r requirements.txt
-    echo "creating artifacts/lambda-${fn}.zip with `find . -type f | wc -l` files"
+    echo "creating artifacts/lambda-${fn}.zip with $(find . -type f | wc -l) files"
     [ -z $VERBOSE ] && Z_QUIET='-q' || Z_QUIET=''
     zip $Z_QUIET -r $ARTIFACT_PATH/lambda-$fn.zip .
 done
@@ -151,13 +151,13 @@ zip $Z_QUIET -r $ARTIFACT_PATH/aws-ecs-additions.zip ./*
 
 
 # package container code
-echo "packaging container definitions with `find $SOURCE_PATH/containers -type f | wc -l` files"
+echo "packaging container definitions with $(find $SOURCE_PATH/containers -type f | wc -l) files"
 cd $SOURCE_PATH/containers
 zip $Z_QUIET -r $ARTIFACT_PATH/containers.zip ./*
 
 
 # add templates to dist
-echo "copying `find $SOURCE_PATH/templates/ -type f | wc -l` cloudformation templates"
+echo "copying $(find $SOURCE_PATH/templates/ -type f | wc -l) cloudformation templates"
 cp $VERBOSE -R $SOURCE_PATH/templates/. $TEMPLATES_PATH
 
 

--- a/src/containers/nextflow/Dockerfile
+++ b/src/containers/nextflow/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION=latest
-FROM nextflow/nextflow:${VERSION} AS build
+FROM public.ecr.aws/seqera-labs/nextflow:${VERSION} AS build
 
 # The upstream nextflow containers are based on alpine
 # which are not compatible with the aws cli


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`deploy.sh`:

* Add `--verbose` flag
* Add `--public` flag
* Only use `--acl public-read` in `git sync` when public flag true
* Move `make-dist.sh` call to after flag processing to allow passing verbose flag
* Move `mkdocs build` to inside `site()`
* Use absolute path to call `make-dist.sh`
* Remove `--acl public-read` from `s3-sync()`
* Allow bucket names without `s3://` prefix

`add-dist.sh`:

* Add parameters with `--verbose` flag
* Use absolute paths throughout
* Add precautionary path test before deleting old dist
* Verbose flag replaces `v` flag with summary statement in `tar`, `cp`, `pip`, `zip` commands 
* Catch rate limited failed calls to api.github.com

`configure-deploy.sh`
* Add `--clobber` flag
* Only overwrite `.aws/config` on clobber flag or user approval

`.travis.yml`
* Use clobber parameter when calling `configure-deploy.sh`
* Use public and verbose parameters when calling `deploy.sh`

`nextflow/Dockerfile`
* Source nextflow image from public.ecr.aws/seqera-labs/nextflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
