### PR TITLE
update job queue and compute environment guidance

### DIFF
--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -256,9 +256,7 @@ Resources:
       ComputeEnvironmentOrder:
         - Order: 1
           ComputeEnvironment: !Ref SpotComputeEnv
-        - Order: 2
-          ComputeEnvironment: !Ref OnDemandComputeEnv
-
+        
   ContainerInstanceLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
*Description of changes:*
Updates recommended guidance on batch job queue and compute environment configuration. Specifically, the "default" job queue schedules jobs to **only** the "spot" compute environment. Spillover from "spot" to "on-demand" is no longer recommended because of new Batch allocation strategies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
