### PR TITLE
Config files

### DIFF
--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -411,6 +411,15 @@ Resources:
                     port = 8000
                   }
 
+                  akka {
+                    http {
+                      server {
+                        request-timeout = 300s
+                        idle-timeout = 300s
+                      }
+                    }
+                  }
+
                   system {
                     job-rate-control {
                       jobs = 1

--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -606,6 +606,15 @@ Resources:
               owner: "ec2-user"
               group: "ec2-user"
 
+            "/home/ec2-user/.aws/config":
+              content: !Sub |
+                [default]
+                region = ${AWS::Region}
+
+              mode: "000644"
+              owner: "ec2-user"
+              group: "ec2-user"
+
           commands:
             00_get_instance_id:
               command: curl -s http://169.254.169.254/latest/meta-data/instance-id/ > /etc/instance-id


### PR DESCRIPTION
*Description of changes:*
- Add server timeouts parameters to `cromwell.conf`
- S3fs in cromwell sometimes fail to set the region when there are a lot of scatter tasks, so, adding region to `.aws/config` fix this issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
