### PR TITLE
Fix graceful cancellation behavior for Nextflow

### DIFF
--- a/src/containers/nextflow/nextflow.aws.sh
+++ b/src/containers/nextflow/nextflow.aws.sh
@@ -81,8 +81,9 @@ function show_log() {
 }
 
 function cleanup() {
-    set -e
+    set +e
     wait $NEXTFLOW_PID
+    set -e
     echo "=== Running Cleanup ==="
 
     show_log
@@ -99,12 +100,13 @@ function cancel() {
     echo "=== !! CANCELLING WORKFLOW !! ==="
     echo "stopping nextflow pid: $NEXTFLOW_PID"
     kill -TERM "$NEXTFLOW_PID"
+    echo "waiting .."
     wait $NEXTFLOW_PID
     echo "=== !! cancellation complete !! ==="
     set -e
 }
 
-trap "cancel" TERM
+trap "cancel; cleanup" TERM
 trap "cleanup" EXIT
 
 # stage workflow definition
@@ -122,4 +124,5 @@ nextflow run $NEXTFLOW_PROJECT $NEXTFLOW_PARAMS &
 NEXTFLOW_PID=$!
 echo "nextflow pid: $NEXTFLOW_PID"
 jobs
+echo "waiting .."
 wait $NEXTFLOW_PID

--- a/src/ecs-additions/ecs-additions-common.sh
+++ b/src/ecs-additions/ecs-additions-common.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# ecs config options
+# graceful shutdown of jobs on spot instances if spot is terminated
+echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
+# cache already pulled container images and reduce network traffic
+echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
+
 # add fetch and run batch helper script
 chmod a+x /opt/ecs-additions/fetch_and_run.sh
 cp /opt/ecs-additions/fetch_and_run.sh /usr/local/bin

--- a/src/ecs-additions/ecs-additions-common.sh
+++ b/src/ecs-additions/ecs-additions-common.sh
@@ -5,6 +5,8 @@
 echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
 # cache already pulled container images and reduce network traffic
 echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
+# increase docker stop timeout so that containers can perform cleanup actions
+echo ECS_CONTAINER_STOP_TIMEOUT=60 >> /etc/ecs/ecs.config
 
 # add fetch and run batch helper script
 chmod a+x /opt/ecs-additions/fetch_and_run.sh

--- a/src/templates/gwfcore/gwfcore-launch-template.template.yaml
+++ b/src/templates/gwfcore/gwfcore-launch-template.template.yaml
@@ -185,12 +185,6 @@ Resources:
                 - export GWFCORE_NAMESPACE=${Namespace}
                 - export INSTALLED_ARTIFACTS_S3_ROOT_URL=$(aws ssm get-parameter --name /gwfcore/${Namespace}/installed-artifacts/s3-root-url --query 'Parameter.Value' --output text)
 
-                # enable ecs spot instance draining
-                - echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
-
-                # pull docker images only if missing
-                - echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
-
                 - cd /opt
                 - aws s3 sync $INSTALLED_ARTIFACTS_S3_ROOT_URL/ecs-additions ./ecs-additions
                 - chmod a+x /opt/ecs-additions/provision.sh


### PR DESCRIPTION
*Description of changes:*
Fix ability of Nextflow to gracefully cancel workflows when receiving a job termination request from Batch. Specifically, in scenarios where the cleanup process (cancelling pending jobs, preserving session cache) take longer than 10s (the default `docker stop` timeout).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
