### PR TITLE
Fix awscli-shim error when arguments contain a space

### DIFF
--- a/src/ecs-additions/awscli-shim.sh
+++ b/src/ecs-additions/awscli-shim.sh
@@ -13,5 +13,5 @@ AWS=$DIST_DIR/aws
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DIST_DIR
 
-$AWS $@
+$AWS "$@"
 


### PR DESCRIPTION
This is related to issue #146

Add quotes around the `$@` argument in the awscli-shim script. 

Without the quotes, files with spaces in them fail to stage with an error like the one shown in the issue.

With the quotes the command runs properly.
```
./shim.sh s3 ls s3://<bucket>/resources/data/references/barcodes/test\ space/barcode.txt
2022-03-30 12:24:34       1744 barcode.txt
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
