### PR TITLE
Fix failing ContainerBuildNextflow step in the nextflow resources stack

### DIFF
--- a/src/containers/nextflow/Dockerfile
+++ b/src/containers/nextflow/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=build /usr/local/bin/nextflow /usr/bin/nextflow
 RUN yum update -y \
  && yum install -y \
     curl \
+    which \
     hostname \
     java \
     unzip \


### PR DESCRIPTION
The nextflow resources stack is failing at the ContainerBuildNextflow step. I tried it using Nextflow `latest`, `22.04.0`, and `21.10.6` but all point to the same error. Below is the codebuild section where it fails:

```bash
Step 9/13 : RUN nextflow -version
--
544 | ---> Running in 414cf77eb8d3
545 | /usr/bin/nextflow: line 275: which: command not found
546 | Downloading nextflow dependencies. It may require a few seconds, please wait ..
547 | 2/3 KB
... 
/usr/bin/nextflow: line 155: /root/.nextflow/capsule/apps/nextflow_22.04.0/java: No such file or directory
The command '/bin/sh -c nextflow -version' returned a non-zero code: 127
```

*Description of changes:*
- Install `which` in the final amazonlinux:2 image so that nextflow can download its dependencies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
