### PR TITLE
Resolve Nextflow build issue

### DIFF
--- a/src/containers/nextflow/Dockerfile
+++ b/src/containers/nextflow/Dockerfile
@@ -1,16 +1,8 @@
 ARG VERSION=latest
 FROM public.ecr.aws/seqera-labs/nextflow:${VERSION} AS build
 
-# The upstream nextflow containers are based on alpine
-# which are not compatible with the aws cli
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS final
-COPY --from=build /usr/local/bin/nextflow /usr/bin/nextflow
-
 RUN yum update -y \
  && yum install -y \
-    curl \
-    hostname \
-    java \
     unzip \
  && yum clean -y all
 RUN rm -rf /var/cache/yum
@@ -20,11 +12,6 @@ RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/
  && unzip -q /tmp/awscliv2.zip -d /tmp \
  && /tmp/aws/install -b /usr/bin \
  && rm -rf /tmp/aws*
-
-ENV JAVA_HOME /usr/lib/jvm/jre-openjdk/
-
-# invoke nextflow once to download dependencies
-RUN nextflow -version
 
 # install a custom entrypoint script that handles being run within an AWS Batch Job
 COPY nextflow.aws.sh /opt/bin/nextflow.aws.sh


### PR DESCRIPTION
*Issue #, if available:*
#199 , #200

*Description of changes:*
Update the Dockerfile for nextflow to account for the upstream base image changing from `alpine` to `amazoncorretto`. The Dockerfile here can now be simplified to just installing the AWS CLI v2 and setting a new entrypoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
