### PR TITLE
remove 'n' instances from default

### DIFF
--- a/src/templates/gwfcore/gwfcore-root.template.yaml
+++ b/src/templates/gwfcore/gwfcore-root.template.yaml
@@ -198,8 +198,12 @@ Parameters:
 
   BatchComputeInstanceTypes:
     Type: String
-    Description: The list of instance types to be used for EC2 instances using Batch Compute Environments.
-    Default: "c4.large,m4.large,r4.large,c4.xlarge,m4.xlarge,r4.xlarge,c4.2xlarge,m4.2xlarge,r4.2xlarge,c4.4xlarge,m4.4xlarge,r4.4xlarge,c5.large,m5.large,r5.large,c5.xlarge,m5.xlarge,r5.xlarge,c5.2xlarge,m5.2xlarge,r5.2xlarge,c5.4xlarge,m5.4xlarge,r5.4xlarge,c5n.large,m5n.large,r5n.large,c5n.xlarge,m5n.xlarge,r5n.xlarge,c5n.2xlarge,m5n.2xlarge,r5n.2xlarge,c5n.4xlarge,m5n.4xlarge,r5n.4xlarge"
+    Description: >-
+      The list of instance types to be used for EC2 instances using Batch Compute Environments.
+      This list works for the majority of genomics workflow tooling. 
+      If you have tooling that requires more compute resources, you can add larger (e.g. *.8xlarge and up) instance types.
+      If you have workflows that read large amounts of data, but otherwise have modest compute resource needs, you can add "n" instances (e.g. c5n, m5n, r5n) - note check availability in your region.
+    Default: "c4.large,m4.large,r4.large,c4.xlarge,m4.xlarge,r4.xlarge,c4.2xlarge,m4.2xlarge,r4.2xlarge,c4.4xlarge,m4.4xlarge,r4.4xlarge,c5.large,m5.large,r5.large,c5.xlarge,m5.xlarge,r5.xlarge,c5.2xlarge,m5.2xlarge,r5.2xlarge,c5.4xlarge,m5.4xlarge,r5.4xlarge"
 
 Conditions:
   NoNamespace: !Equals [ !Ref Namespace, "" ]


### PR DESCRIPTION
*Issue #, if available:*
#196

*Description of changes:*
Remove "n" instance types (e.g. c5n, m5n, r5n) from the default list of instance types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
